### PR TITLE
Tell Cargo it needs to use +nightly by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ glifparser = { git = "https://github.com/MFEK/glifparser.rlib", branch = "mfek",
 log = "0.4.14"
 env_logger = "0.8"
 dircpy = "0.3.6"
+
+[profile.release]
+lto = true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use `ufostroker --help`, `ufostroker noodle --help` or `ufostroker pattern --hel
 
 ## To build
 
-* Install rust
+* Install Rust (a nightly toolchain is required, typically with `rustup toolchain install nightly`)
 * `cargo build --release`
 * Find the binary in `target/release`
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
The current documented `cargo build --release` only works for people that happen to have the nightly toolchain set as their default. This is not uncommon among developers but should not be assumed. The alternatives are to document needing to run `cargo +nightly build --release` instead or adding this flag file so that Cargo picks up on it automatically.